### PR TITLE
Handle errors and make small fixes

### DIFF
--- a/thesis-api-v2/src/main/java/pl/edu/agh/quizzesthesis/business/service/DefinitionProcessingService.java
+++ b/thesis-api-v2/src/main/java/pl/edu/agh/quizzesthesis/business/service/DefinitionProcessingService.java
@@ -144,7 +144,7 @@ public class DefinitionProcessingService {
                 }
             }
 
-           var distanceValueKeys = distancesToRightAnswer.entrySet().stream()
+            var distanceValueKeys = distancesToRightAnswer.entrySet().stream()
                     .sorted((a, b) -> Float.compare(a.getValue(), b.getValue()))
                     .limit(limitDistanceValueKeys(distancesToRightAnswer))
                     .map(Map.Entry::getKey)
@@ -172,6 +172,24 @@ public class DefinitionProcessingService {
             }
             String newDefinition = String.join("", summaryCensored).replace(WHITE_SPACE_REPLACER, " ");
             return new DefinitionProcessing(newDefinition, answer, articleTitle);
+        }
+
+        public DefinitionProcessing removeInBracketsFromDefinition() {
+            String text = definition;
+            if (text.length() > 1 && text.charAt(text.length() - 2) == '.') {
+                text = text.substring(0, text.length() - 1);
+            }
+            int startIndex = text.indexOf("(");
+            int endIndex = text.indexOf(")");
+            while (startIndex != -1 && endIndex != -1) {
+                System.out.println("tutaj się blokuje z tekstem: " + text + "znalazłem nawiasy na indexach " + startIndex + " i " + endIndex);
+                String replacement = "";
+                String toBeReplaced = text.substring(startIndex, endIndex + 1);
+                text = text.replace(toBeReplaced, replacement);
+                startIndex = text.indexOf("(");
+                endIndex = text.indexOf(")");
+            }
+            return new DefinitionProcessing(text, answer, articleTitle);
         }
 
         private int limitDistanceValueKeys(Map<String, Float> distancesToRightAnswer) {

--- a/thesis-api-v2/src/main/java/pl/edu/agh/quizzesthesis/business/service/DefinitionProcessingService.java
+++ b/thesis-api-v2/src/main/java/pl/edu/agh/quizzesthesis/business/service/DefinitionProcessingService.java
@@ -174,15 +174,16 @@ public class DefinitionProcessingService {
             return new DefinitionProcessing(newDefinition, answer, articleTitle);
         }
 
-        public DefinitionProcessing removeInBracketsFromDefinition() {
+        public DefinitionProcessing removeTextInBracketsFromDefinition() {
             String text = definition;
-            if (text.length() > 1 && text.charAt(text.length() - 2) == '.') {
-                text = text.substring(0, text.length() - 1);
-            }
             int startIndex = text.indexOf("(");
             int endIndex = text.indexOf(")");
             while (startIndex != -1 && endIndex != -1) {
-                System.out.println("tutaj się blokuje z tekstem: " + text + "znalazłem nawiasy na indexach " + startIndex + " i " + endIndex);
+                int potentialStartIndex = text.indexOf("(", startIndex + 1);
+                while (potentialStartIndex != -1 && potentialStartIndex < endIndex) {
+                    endIndex = text.indexOf(")", endIndex + 1);
+                    potentialStartIndex = text.indexOf("(", potentialStartIndex + 1);
+                }
                 String replacement = "";
                 String toBeReplaced = text.substring(startIndex, endIndex + 1);
                 text = text.replace(toBeReplaced, replacement);

--- a/thesis-api-v2/src/main/java/pl/edu/agh/quizzesthesis/business/service/DefinitionProcessingService.java
+++ b/thesis-api-v2/src/main/java/pl/edu/agh/quizzesthesis/business/service/DefinitionProcessingService.java
@@ -184,6 +184,8 @@ public class DefinitionProcessingService {
                     endIndex = text.indexOf(")", endIndex + 1);
                     potentialStartIndex = text.indexOf("(", potentialStartIndex + 1);
                 }
+                if (endIndex == -1)
+                    endIndex = text.length();
                 String replacement = "";
                 String toBeReplaced = text.substring(startIndex, endIndex + 1);
                 text = text.replace(toBeReplaced, replacement);

--- a/thesis-api-v2/src/main/java/pl/edu/agh/quizzesthesis/business/service/DefinitionQuestionService.java
+++ b/thesis-api-v2/src/main/java/pl/edu/agh/quizzesthesis/business/service/DefinitionQuestionService.java
@@ -28,7 +28,7 @@ public class DefinitionQuestionService implements QuestionService<DefinitionQues
                 .startProcessing(definitionArticle.definition(), term.getName(), definitionArticle.articleTitle())
                 .standardizeDefinitionLength()
                 .removeAnswerFromDefinition()
-                .removeInBracketsFromDefinition()
+                .removeTextInBracketsFromDefinition()
                 .getDefinition();
 
         var answers = wrongAnswerService.prepareAnswers(term);

--- a/thesis-api-v2/src/main/java/pl/edu/agh/quizzesthesis/business/service/DefinitionQuestionService.java
+++ b/thesis-api-v2/src/main/java/pl/edu/agh/quizzesthesis/business/service/DefinitionQuestionService.java
@@ -27,8 +27,8 @@ public class DefinitionQuestionService implements QuestionService<DefinitionQues
         String processedDefinition = definitionProcessingService
                 .startProcessing(definitionArticle.definition(), term.getName(), definitionArticle.articleTitle())
                 .standardizeDefinitionLength()
-                .removeAnswerFromDefinition()
                 .removeTextInBracketsFromDefinition()
+                .removeAnswerFromDefinition()
                 .getDefinition();
 
         var answers = wrongAnswerService.prepareAnswers(term);

--- a/thesis-api-v2/src/main/java/pl/edu/agh/quizzesthesis/business/service/DefinitionQuestionService.java
+++ b/thesis-api-v2/src/main/java/pl/edu/agh/quizzesthesis/business/service/DefinitionQuestionService.java
@@ -28,6 +28,7 @@ public class DefinitionQuestionService implements QuestionService<DefinitionQues
                 .startProcessing(definitionArticle.definition(), term.getName(), definitionArticle.articleTitle())
                 .standardizeDefinitionLength()
                 .removeAnswerFromDefinition()
+                .removeInBracketsFromDefinition()
                 .getDefinition();
 
         var answers = wrongAnswerService.prepareAnswers(term);

--- a/thesis-api-v2/src/main/java/pl/edu/agh/quizzesthesis/business/service/WrongAnswerService.java
+++ b/thesis-api-v2/src/main/java/pl/edu/agh/quizzesthesis/business/service/WrongAnswerService.java
@@ -44,7 +44,7 @@ public class WrongAnswerService {
             throw new ExternalServiceException("Error while querying Datamuse", e);
         }
 
-        var relatedNounsSorted = relatedWords.stream()
+        var relatedNouns = relatedWords.stream()
                 .filter(word -> word.getTags().contains("n") && !word.getTags().contains("syn"))
                 .map(word -> new TermSetupService.WordFrequency(word.getWord(), Float.parseFloat(word.getTags().get(word.getTags().size() - 1).substring(2))))
                 .sorted((wf1, wf2) -> Float.compare(wf1.frequency(), wf2.frequency()))
@@ -52,7 +52,7 @@ public class WrongAnswerService {
 
 
         var wrongAnswers = new ArrayList<String>();
-        for (var potentialAnswer : relatedNounsSorted) {
+        for (var potentialAnswer : relatedNouns) {
             if (wrongAnswers.size() == 3) {
                 break;
             }
@@ -88,7 +88,7 @@ public class WrongAnswerService {
         }
 
         if (wrongAnswers.size() < 3) {
-            for (var potentialAnswer : relatedNounsSorted) {
+            for (var potentialAnswer : relatedNouns) {
                 if (wrongAnswers.size() == 3) {
                     break;
                 }

--- a/thesis-api-v2/src/main/java/pl/edu/agh/quizzesthesis/business/service/WrongAnswerService.java
+++ b/thesis-api-v2/src/main/java/pl/edu/agh/quizzesthesis/business/service/WrongAnswerService.java
@@ -18,7 +18,6 @@ import static com.szadowsz.datamuse.DatamuseParam.META_FLAG_F;
 @AllArgsConstructor
 public class WrongAnswerService {
 
-    private static final float FREQUENCY_THRESHOLD = 0.25f;
     private static final float ANSWER_CHOICE_PROBABILITY = 0.7f;
     private static final float EDIT_DISTANCE = 2.0f;
 
@@ -51,18 +50,13 @@ public class WrongAnswerService {
                 .sorted((wf1, wf2) -> Float.compare(wf1.frequency(), wf2.frequency()))
                 .toList();
 
-        float minimumFrequencyThreshold = relatedNounsSorted.size() > 0
-                ? relatedNounsSorted.get((int) (relatedNounsSorted.size() * FREQUENCY_THRESHOLD)).frequency()
-                : 0;
 
         var wrongAnswers = new ArrayList<String>();
         for (var potentialAnswer : relatedNounsSorted) {
             if (wrongAnswers.size() == 3) {
                 break;
             }
-            if (potentialAnswer.frequency() < minimumFrequencyThreshold) {
-                continue;
-            }
+
             if (random.nextFloat(1.0f) > ANSWER_CHOICE_PROBABILITY) {
                 continue;
             }
@@ -98,9 +92,15 @@ public class WrongAnswerService {
                 if (wrongAnswers.size() == 3) {
                     break;
                 }
-                if (potentialAnswer.frequency() > minimumFrequencyThreshold && !wrongAnswers.contains(potentialAnswer.word())) {
+                if (!wrongAnswers.contains(potentialAnswer.word())) {
                     wrongAnswers.add(potentialAnswer.word());
                 }
+            }
+        }
+        while (wrongAnswers.size() < 3) {
+            var potentialAnswer = termService.getRandom(rightAnswerTerm.getSearchPhrase().getCategory().getId());
+            if (!wrongAnswers.contains(potentialAnswer.getName())) {
+                wrongAnswers.add(potentialAnswer.getName());
             }
         }
         return wrongAnswers;

--- a/thesis-api-v2/src/main/java/pl/edu/agh/quizzesthesis/business/service/WrongAnswerService.java
+++ b/thesis-api-v2/src/main/java/pl/edu/agh/quizzesthesis/business/service/WrongAnswerService.java
@@ -47,7 +47,6 @@ public class WrongAnswerService {
         var relatedNouns = relatedWords.stream()
                 .filter(word -> word.getTags().contains("n") && !word.getTags().contains("syn"))
                 .map(word -> new TermSetupService.WordFrequency(word.getWord(), Float.parseFloat(word.getTags().get(word.getTags().size() - 1).substring(2))))
-                .sorted((wf1, wf2) -> Float.compare(wf1.frequency(), wf2.frequency()))
                 .toList();
 
 

--- a/thesis-api/main/services/question_service/definition_processing_service.py
+++ b/thesis-api/main/services/question_service/definition_processing_service.py
@@ -35,8 +35,8 @@ class DefinitionProcessingService:
         text = self.definition
         if text[-2] == ".":
             text = text[:len(text)-1]
-        delimiters_postfixes = [",", ".", "!", "?", ")", ";", "]"]
-        delimiters_prefixes = ["(", "["]
+        delimiters_postfixes = [",", ".", "!", "?", ";", "]"]
+        delimiters_prefixes = ["["]
         white_space_replacer = "###"
         text = text.replace("  ", " ")
         text = text.replace(" ", " " + white_space_replacer + " ")

--- a/thesis-gui/src/components/quiz/Quiz.tsx
+++ b/thesis-gui/src/components/quiz/Quiz.tsx
@@ -84,7 +84,7 @@ export const Quiz: React.FC = () => {
             .catch(err =>
             {
             console.log(err);
-            setTimeout(getNewQuestion, 100);
+            getNewQuestion();
             });
     }
 

--- a/thesis-gui/src/components/quiz/Quiz.tsx
+++ b/thesis-gui/src/components/quiz/Quiz.tsx
@@ -71,18 +71,21 @@ export const Quiz: React.FC = () => {
 
     const getNewQuestion = () => {
         const randomCategory = getRandom()!;
-
         return questionService.get(randomCategory.id)
             .then(res => {
                 console.log(`Correct answer: ${res.correct.name}`)
-
                 setCategory(randomCategory);
                 setQuestion(res);
                 setSelected(undefined);
                 setQuestionNumber(prev => prev + 1);
-            })
-            .catch(err => console.log(err))
-            .finally(() => setShowResult(false));
+                setShowResult(false)
+            }
+            )
+            .catch(err =>
+            {
+            console.log(err);
+            setTimeout(getNewQuestion, 100);
+            });
     }
 
     return (

--- a/thesis-gui/src/services/question-service.tsx
+++ b/thesis-gui/src/services/question-service.tsx
@@ -7,7 +7,7 @@ import {QuestionResponse} from "../types/question-response";
 export const questionService = {
     get(categoryId: number) {
         const questionType = questionTypeService.getRandom();
-        if (questionType == QuestionType.DEFINITION) {
+        if (questionType === QuestionType.DEFINITION) {
             return definitionQuestionService.get(categoryId);
         } else {
             return pictureQuestionService.get(categoryId);


### PR DESCRIPTION
1. In case of error from unsplash frontend is sending another request to backend
2. Remove sorting the related words in WrongAnswerService and remove frequencyThreshold. In case of not finding 3 wrongAnswers in relatedWords download random term from this category.
3. Remove text in brackets from definitions. 